### PR TITLE
Fix Firebase client initialization

### DIFF
--- a/frontend/src/app/admin/dashboard/page.tsx
+++ b/frontend/src/app/admin/dashboard/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic'; // 정적 생성 끄기
 import { useState, useEffect } from 'react';
 import { collection, query, onSnapshot, doc, updateDoc, DocumentData, Timestamp } from 'firebase/firestore';
 import { db, auth } from '@/lib/firebase';

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic'; // 정적 생성 끄기
 import { useState } from 'react';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 import { auth } from '@/lib/firebase';

--- a/frontend/src/app/auth/signup/page.tsx
+++ b/frontend/src/app/auth/signup/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic'; // 정적 생성 끄기
 import { useState } from 'react';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
 import { doc, setDoc, serverTimestamp } from 'firebase/firestore';

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic'; // 정적 생성 끄기
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { collection, query, where, onSnapshot, DocumentData, Timestamp } from 'firebase/firestore';

--- a/frontend/src/app/payment/success/page.tsx
+++ b/frontend/src/app/payment/success/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic'; // 정적 생성 끄기
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useState, Suspense } from 'react';
 import { httpsCallable } from 'firebase/functions';

--- a/frontend/src/app/products/register/page.tsx
+++ b/frontend/src/app/products/register/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic'; // 정적 생성 끄기
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useForm, SubmitHandler } from 'react-hook-form';

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -17,6 +17,8 @@ const firebaseConfig = {
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 
 export const auth = getAuth(app);
-export const db = getFirestore(app);
-export const storage = getStorage(app);
-export const functions = getFunctions(app, "asia-northeast3");
+// 브라우저 환경에서만 Firestore, Storage, Functions 초기화
+export const db = typeof window !== 'undefined' ? getFirestore(app) : null;
+export const storage = typeof window !== 'undefined' ? getStorage(app) : null;
+export const functions =
+  typeof window !== 'undefined' ? getFunctions(app, 'asia-northeast3') : null;


### PR DESCRIPTION
## Summary
- ensure Firestore pages disable static generation
- only initialize Firestore, Storage and Functions in the browser

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e568a50e4832382431c186b4419af