### PR TITLE
Fix firebase initialization types

### DIFF
--- a/frontend/src/app/admin/dashboard/page.tsx
+++ b/frontend/src/app/admin/dashboard/page.tsx
@@ -43,7 +43,7 @@ export default function AdminDashboardPage() {
   useEffect(() => {
     if (isAdmin === false) return; // 관리자가 아니면 데이터 로드 안함
     if (isAdmin === true) {
-      const q = query(collection(db, 'products'));
+      const q = query(collection<Product>(db, 'products'));
       const unsubscribe = onSnapshot(q, (querySnapshot) => {
         const productsData = querySnapshot.docs.map(doc => ({
           id: doc.id,
@@ -58,7 +58,7 @@ export default function AdminDashboardPage() {
 
   const handleStatusChange = async (productId: string, newStatus: string) => {
     try {
-      const productRef = doc(db, 'products', productId);
+      const productRef = doc<Product>(db, 'products', productId);
       await updateDoc(productRef, { status: newStatus });
       alert('상태가 성공적으로 변경되었습니다.');
     } catch (error) {

--- a/frontend/src/app/auth/signup/page.tsx
+++ b/frontend/src/app/auth/signup/page.tsx
@@ -2,10 +2,17 @@
 export const dynamic = 'force-dynamic'; // 정적 생성 끄기
 import { useState } from 'react';
 import { createUserWithEmailAndPassword } from 'firebase/auth';
-import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
+import { doc, setDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
 import { auth, db, functions } from '@/lib/firebase';
 import { useRouter } from 'next/navigation';
+
+interface Seller {
+  email: string | null;
+  businessNumber: string;
+  isVerified: boolean;
+  createdAt: Timestamp;
+}
 
 export default function SignUpPage() {
   const [email, setEmail] = useState('');
@@ -31,7 +38,7 @@ export default function SignUpPage() {
       const userCredential = await createUserWithEmailAndPassword(auth, email, password);
       const user = userCredential.user;
 
-      await setDoc(doc(db, 'sellers', user.uid), {
+      await setDoc(doc<Seller>(db, 'sellers', user.uid), {
         email: user.email,
         businessNumber: businessNumber,
         isVerified: true,

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -29,7 +29,7 @@ export default function DashboardPage() {
       return;
     }
 
-    const q = query(collection(db, 'products'), where('sellerId', '==', user.uid));
+    const q = query(collection<Product>(db, 'products'), where('sellerId', '==', user.uid));
     const unsubscribe = onSnapshot(q, (querySnapshot) => {
       const productsData = querySnapshot.docs.map(doc => ({
         id: doc.id,

--- a/frontend/src/app/products/register/page.tsx
+++ b/frontend/src/app/products/register/page.tsx
@@ -40,7 +40,7 @@ export default function RegisterProductPage() {
       const uploadResult = await uploadBytes(storageRef, imageFile);
       const imageUrl = await getDownloadURL(uploadResult.ref);
 
-      await addDoc(collection(db, 'products'), {
+      await addDoc(collection<Product>(db, 'products'), {
         sellerId: user.uid,
         name: data.name,
         description: data.description,

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -17,8 +17,7 @@ const firebaseConfig = {
 const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
 
 export const auth = getAuth(app);
-// 브라우저 환경에서만 Firestore, Storage, Functions 초기화
-export const db = typeof window !== 'undefined' ? getFirestore(app) : null;
-export const storage = typeof window !== 'undefined' ? getStorage(app) : null;
-export const functions =
-  typeof window !== 'undefined' ? getFunctions(app, 'asia-northeast3') : null;
+// Firestore, Storage, Functions are safe to initialise in client components
+export const db = getFirestore(app);
+export const storage = getStorage(app);
+export const functions = getFunctions(app, 'asia-northeast3');


### PR DESCRIPTION
## Summary
- initialize Firebase modules unconditionally so Firestore etc. are never `null`
- tighten Firestore usage typings in all pages

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e82a2c07883239bd81612a1b52c03