### PR TITLE
Add seller pages and signup

### DIFF
--- a/components/seller/SellerLayout.js
+++ b/components/seller/SellerLayout.js
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+
+export default function SellerLayout({ children }) {
+  return (
+    <div className="flex">
+      <aside className="w-64 bg-gray-800 text-white min-h-screen p-4">
+        <h1 className="text-2xl font-bold mb-8">판매자 페이지</h1>
+        <nav>
+          <ul>
+            <li className="mb-4">
+              <Link href="/dashboard/products" className="hover:bg-gray-700 p-2 rounded block">
+                예약하기
+              </Link>
+            </li>
+            <li className="mb-4">
+              <Link href="/seller/progress" className="hover:bg-gray-700 p-2 rounded block">
+                진행현황
+              </Link>
+            </li>
+            <li className="mb-4">
+              <Link href="/seller/traffic" className="hover:bg-gray-700 p-2 rounded block">
+                트래픽
+              </Link>
+            </li>
+            <li className="mb-4">
+              <Link href="/seller/keyword" className="hover:bg-gray-700 p-2 rounded block">
+                키워드분석
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </aside>
+      <main className="flex-1 p-8 bg-gray-100">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/pages/dashboard/products.js
+++ b/pages/dashboard/products.js
@@ -4,6 +4,7 @@ import { db, auth } from '../../lib/firebase';
 import { collection, addDoc, deleteDoc, serverTimestamp, query, where, onSnapshot, doc } from 'firebase/firestore';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { signOut } from 'firebase/auth';
+import SellerLayout from '../../components/seller/SellerLayout';
 import { nanoid } from 'nanoid';
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
@@ -169,6 +170,7 @@ export default function DashboardPage() {
   const inputClass = "w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500";
 
   return (
+    <SellerLayout>
     <div className="p-4 md:p-8 bg-gray-50 min-h-screen">
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6">
         <h1 className="text-3xl font-bold text-gray-800">판매자 대시보드</h1>
@@ -320,5 +322,6 @@ export default function DashboardPage() {
         </div>
       </div>
     </div>
+    </SellerLayout>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,14 +1,12 @@
 import { useState, useEffect } from 'react';
 import { auth, db } from '../lib/firebase';
-import { createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut, onAuthStateChanged } from 'firebase/auth';
-import { doc, setDoc, collection, query, where, getDocs } from 'firebase/firestore';
+import { signInWithEmailAndPassword, signOut, onAuthStateChanged, deleteUser } from 'firebase/auth';
+import { doc, getDoc, updateDoc, deleteDoc, serverTimestamp } from 'firebase/firestore';
 import { useRouter } from 'next/router';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [bNo, setBNo] = useState('');
-  const [isVerifying, setIsVerifying] = useState(false);
   const [user, setUser] = useState(null); // 로그인 상태 확인용
   const router = useRouter();
 
@@ -22,9 +20,21 @@ export default function LoginPage() {
 
   const handleLogin = async () => {
     try {
-      await signInWithEmailAndPassword(auth, email, password);
-      // alert('로그인 성공!'); // 알림창 제거
-      router.push('/dashboard/products'); // 즉시 대시보드로 이동
+      const cred = await signInWithEmailAndPassword(auth, email, password);
+      const user = cred.user;
+      const sellerRef = doc(db, 'sellers', user.uid);
+      const sellerSnap = await getDoc(sellerRef);
+      if (sellerSnap.exists()) {
+        const last = sellerSnap.data().lastLogin?.toDate();
+        if (last && Date.now() - last.getTime() > 30 * 24 * 60 * 60 * 1000) {
+          await deleteDoc(sellerRef);
+          await deleteUser(user);
+          alert('30일 이상 미접속으로 계정이 삭제되었습니다. 다시 가입해주세요.');
+          return;
+        }
+        await updateDoc(sellerRef, { lastLogin: serverTimestamp() });
+      }
+      router.push('/seller');
     } catch (error) {
       alert(`로그인 실패: ${error.message}`);
     }
@@ -35,72 +45,6 @@ export default function LoginPage() {
     alert('로그아웃 되었습니다.');
   };
 
-  const handleSignUpAndVerify = async (e) => {
-    e.preventDefault();
-    if (!email || !password || !bNo) {
-      alert('모든 필드를 입력해주세요.');
-      return;
-    }
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
-      alert('올바른 이메일 형식을 입력해주세요.');
-      return;
-    }
-    setIsVerifying(true);
-
-    try {
-      // ✅ 1. 이메일 중복 확인 (Firestore 직접 조회)
-      const emailQuery = query(collection(db, 'sellers'), where('email', '==', email));
-      const emailQuerySnapshot = await getDocs(emailQuery);
-      if (!emailQuerySnapshot.empty) {
-        throw new Error('이미 사용 중인 이메일입니다.');
-      }
-
-      // ✅ 2. 사업자 번호 중복 확인 (Firestore 직접 조회)
-      const bNoQuery = query(collection(db, 'sellers'), where('businessInfo.b_no', '==', bNo));
-      const bNoQuerySnapshot = await getDocs(bNoQuery);
-      if (!bNoQuerySnapshot.empty) {
-        throw new Error('이미 등록된 사업자 번호입니다.');
-      }
-
-      // 3. 사업자 인증 API 호출
-      const response = await fetch('/api/business/verify', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ b_no: bNo })
-      });
-
-      const data = await response.json();
-
-      if (response.ok && data.b_stt_cd === '01') {
-        // 4. Firebase Auth 사용자 생성
-        const userCredential = await createUserWithEmailAndPassword(auth, email, password);
-        const user = userCredential.user;
-
-        // 5. Firestore에 판매자 정보 저장
-        await setDoc(doc(db, "sellers", user.uid), {
-          uid: user.uid,
-          email: user.email,
-          businessInfo: data,
-          isVerified: true,
-          paymentStatus: 'unpaid',
-          // 초기 결제 금액 설정. 관리자가 변경 가능
-          paymentAmount: 50000 
-        });
-
-        alert(`${data.tax_type} 사업자 인증 및 가입이 완료되었습니다. 바로 로그인됩니다.`);
-        router.push('/dashboard/products'); // 가입 후 바로 대시보드로 이동
-
-      } else {
-        alert(`인증 실패: ${data.b_stt || data.message || '알 수 없는 오류'}`);
-      }
-    } catch (error) {
-      console.error(error);
-      alert(`가입 과정에서 오류가 발생했습니다: ${error.message}`);
-    } finally {
-      setIsVerifying(false);
-    }
-  };
 
   return (
     <div style={{ padding: '20px', maxWidth: '400px', margin: 'auto' }}>
@@ -110,7 +54,7 @@ export default function LoginPage() {
       {user ? (
         <div style={{ border: '1px solid #ccc', padding: '20px', marginBottom: '20px', textAlign: 'center' }}>
           <p>{user.email}님, 환영합니다.</p>
-          <button onClick={() => router.push('/dashboard/products')} style={{ width: '100%', padding: '10px', marginTop: '10px' }}>대시보드로 이동</button>
+          <button onClick={() => router.push('/seller')} style={{ width: '100%', padding: '10px', marginTop: '10px' }}>대시보드로 이동</button>
           <button onClick={handleLogout} style={{ width: '100%', padding: '10px', marginTop: '10px', backgroundColor: 'grey', color: 'white' }}>로그아웃</button>
         </div>
       ) : (
@@ -120,18 +64,7 @@ export default function LoginPage() {
             <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="이메일" style={{ width: '100%', padding: '8px', marginBottom: '10px' }} />
             <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="비밀번호" style={{ width: '100%', padding: '8px', marginBottom: '10px' }} />
             <button onClick={handleLogin} style={{ width: '100%', padding: '10px' }}>로그인</button>
-          </div>
-
-          <div style={{ border: '1px solid #ccc', padding: '20px' }}>
-            <h2>회원가입 및 사업자 인증</h2>
-            <form onSubmit={handleSignUpAndVerify}>
-              <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="이메일 (위와 동일하게 사용)" style={{ width: '100%', padding: '8px', marginBottom: '10px' }} />
-              <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="비밀번호 (위와 동일하게 사용)" style={{ width: '100%', padding: '8px', marginBottom: '10px' }} />
-              <input value={bNo} onChange={(e) => setBNo(e.target.value.replace(/-/g, ''))} placeholder="사업자등록번호 ('-' 제외)" required style={{ width: '100%', padding: '8px', marginBottom: '10px' }} />
-              <button type="submit" disabled={isVerifying} style={{ width: '100%', padding: '10px' }}>
-                {isVerifying ? '인증 중...' : '가입 및 인증하기'}
-              </button>
-            </form>
+            <button onClick={() => router.push('/signup')} style={{ width: '100%', padding: '10px', marginTop: '10px' }}>회원가입</button>
           </div>
         </>
       )}

--- a/pages/seller/index.js
+++ b/pages/seller/index.js
@@ -1,0 +1,10 @@
+import SellerLayout from '../../components/seller/SellerLayout';
+
+export default function SellerHome() {
+  return (
+    <SellerLayout>
+      <h2 className="text-2xl font-bold mb-4">예약 시트</h2>
+      <p>일주일 단위 예약 일정이 이곳에 표시됩니다. (준비 중)</p>
+    </SellerLayout>
+  );
+}

--- a/pages/seller/keyword.js
+++ b/pages/seller/keyword.js
@@ -1,0 +1,10 @@
+import SellerLayout from '../../components/seller/SellerLayout';
+
+export default function KeywordPage() {
+  return (
+    <SellerLayout>
+      <h2 className="text-2xl font-bold mb-4">키워드 분석</h2>
+      <p>네이버 데이터랩 연동 예정입니다.</p>
+    </SellerLayout>
+  );
+}

--- a/pages/seller/progress.js
+++ b/pages/seller/progress.js
@@ -1,0 +1,10 @@
+import SellerLayout from '../../components/seller/SellerLayout';
+
+export default function ProgressPage() {
+  return (
+    <SellerLayout>
+      <h2 className="text-2xl font-bold mb-4">진행현황</h2>
+      <p>관리자가 설정한 상태에 따라 진행 상황이 표시됩니다. (준비 중)</p>
+    </SellerLayout>
+  );
+}

--- a/pages/seller/traffic.js
+++ b/pages/seller/traffic.js
@@ -1,0 +1,10 @@
+import SellerLayout from '../../components/seller/SellerLayout';
+
+export default function TrafficPage() {
+  return (
+    <SellerLayout>
+      <h2 className="text-2xl font-bold mb-4">트래픽</h2>
+      <p>순번, 종류, 진행일자, 종료일자 등이 표시됩니다. (준비 중)</p>
+    </SellerLayout>
+  );
+}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { auth, db } from '../lib/firebase';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { doc, setDoc, collection, query, where, getDocs, serverTimestamp } from 'firebase/firestore';
+
+export default function SignupPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [bNo, setBNo] = useState('');
+  const [referrerId, setReferrerId] = useState('');
+  const [username, setUsername] = useState('');
+  const [isVerifying, setIsVerifying] = useState(false);
+  const router = useRouter();
+
+  const handleSignUpAndVerify = async (e) => {
+    e.preventDefault();
+    if (!email || !password || !bNo || !name || !phone || !username) {
+      alert('모든 필드를 입력해주세요.');
+      return;
+    }
+    setIsVerifying(true);
+    try {
+      const emailQuery = query(collection(db, 'sellers'), where('email', '==', email));
+      const emailSnap = await getDocs(emailQuery);
+      if (!emailSnap.empty) throw new Error('이미 사용 중인 이메일입니다.');
+
+      const bNoQuery = query(collection(db, 'sellers'), where('businessInfo.b_no', '==', bNo));
+      const bNoSnap = await getDocs(bNoQuery);
+      if (!bNoSnap.empty) throw new Error('이미 등록된 사업자 번호입니다.');
+
+      const response = await fetch('/api/business/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ b_no: bNo })
+      });
+
+      const data = await response.json();
+      if (response.ok && data.b_stt_cd === '01') {
+        const cred = await createUserWithEmailAndPassword(auth, email, password);
+        const user = cred.user;
+        await setDoc(doc(db, 'sellers', user.uid), {
+          uid: user.uid,
+          email,
+          name,
+          phone,
+          username,
+          referrerId,
+          businessInfo: data,
+          isVerified: true,
+          paymentStatus: 'unpaid',
+          paymentAmount: 50000,
+          lastLogin: serverTimestamp()
+        });
+        alert(`${data.tax_type} 사업자 인증 및 가입이 완료되었습니다.`);
+        router.push('/');
+      } else {
+        alert(`인증 실패: ${data.b_stt || data.message || '알 수 없는 오류'}`);
+      }
+    } catch (err) {
+      console.error(err);
+      alert(`가입 과정에서 오류가 발생했습니다: ${err.message}`);
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: '20px', maxWidth: '400px', margin: 'auto' }}>
+      <h1>회원가입</h1>
+      <form onSubmit={handleSignUpAndVerify}>
+        <input value={name} onChange={e => setName(e.target.value)} placeholder="이름" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
+        <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="이메일" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
+        <input value={phone} onChange={e => setPhone(e.target.value)} placeholder="전화번호" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
+        <input value={bNo} onChange={e => setBNo(e.target.value.replace(/-/g,''))} placeholder="사업자등록번호('-' 제외)" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
+        <input value={referrerId} onChange={e => setReferrerId(e.target.value)} placeholder="추천인 ID" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
+        <input value={username} onChange={e => setUsername(e.target.value)} placeholder="ID" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="PW" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
+        <button type="submit" disabled={isVerifying} style={{ width:'100%', padding:'10px' }}>
+          {isVerifying ? '인증 중...' : '가입하기'}
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create SellerLayout with tabs similar to admin
- make new seller pages (home, progress, traffic, keyword)
- create a signup page with business verification
- show login screen first and route to signup page when needed
- update dashboard to use SellerLayout
- add 30-day inactivity check during login

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629d9ebb1083238ec5e85d6bd9d761