### PR TITLE
Implement seller dashboard features

### DIFF
--- a/components/seller/SellerLayout.js
+++ b/components/seller/SellerLayout.js
@@ -8,6 +8,11 @@ export default function SellerLayout({ children }) {
         <nav>
           <ul>
             <li className="mb-4">
+              <Link href="/seller" className="hover:bg-gray-700 p-2 rounded block">
+                예약 시트
+              </Link>
+            </li>
+            <li className="mb-4">
               <Link href="/dashboard/products" className="hover:bg-gray-700 p-2 rounded block">
                 예약하기
               </Link>

--- a/pages/admin/products.js
+++ b/pages/admin/products.js
@@ -123,13 +123,33 @@ function CampaignManagement() {
                       {typeof c.itemTotal === 'number' ? c.itemTotal.toLocaleString() + '원' : '견적 정보 없음'}
                     </td>
                     <td className="px-3 py-4 whitespace-nowrap text-sm">
-                      <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${c.status === '예약 확정' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}>
+                      <span
+                        className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
+                          c.status === '리뷰완료'
+                            ? 'bg-blue-100 text-blue-800'
+                            : c.status === '구매완료'
+                            ? 'bg-green-200 text-green-800'
+                            : c.status === '예약 확정'
+                            ? 'bg-green-100 text-green-800'
+                            : 'bg-yellow-100 text-yellow-800'
+                        }`}
+                      >
                         {c.status || '상태 없음'}
                       </span>
                     </td>
-                    <td className="px-3 py-4 whitespace-nowrap text-sm">
-                      {c.status !== '예약 확정' && <button onClick={() => handleUpdateStatus(c.id, '예약 확정')} className="text-indigo-600 hover:text-indigo-900 mr-4">확정</button>}
-                      {c.status !== '미확정' && <button onClick={() => handleUpdateStatus(c.id, '미확정')} className="text-gray-500 hover:text-gray-700">미확정</button>}
+                    <td className="px-3 py-4 whitespace-nowrap text-sm space-x-2">
+                      {c.status !== '예약 확정' && (
+                        <button onClick={() => handleUpdateStatus(c.id, '예약 확정')} className="text-indigo-600 hover:text-indigo-900">확정</button>
+                      )}
+                      {c.status !== '미확정' && (
+                        <button onClick={() => handleUpdateStatus(c.id, '미확정')} className="text-gray-500 hover:text-gray-700">미확정</button>
+                      )}
+                      {c.status !== '구매완료' && (
+                        <button onClick={() => handleUpdateStatus(c.id, '구매완료')} className="text-green-600 hover:text-green-800">구매완료</button>
+                      )}
+                      {c.status !== '리뷰완료' && (
+                        <button onClick={() => handleUpdateStatus(c.id, '리뷰완료')} className="text-blue-600 hover:text-blue-800">리뷰완료</button>
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/pages/seller/index.js
+++ b/pages/seller/index.js
@@ -1,10 +1,67 @@
+import { useEffect, useState } from 'react';
 import SellerLayout from '../../components/seller/SellerLayout';
+import { db } from '../../lib/firebase';
+import { collection, query, where, onSnapshot, Timestamp, getDoc, doc } from 'firebase/firestore';
 
 export default function SellerHome() {
+  const [schedule, setSchedule] = useState({});
+
+  useEffect(() => {
+    const today = new Date();
+    const day = today.getDay();
+    const diff = today.getDate() - day + (day === 0 ? -6 : 1); // Monday as start
+    const monday = new Date(today.setDate(diff));
+    monday.setHours(0, 0, 0, 0);
+    const sunday = new Date(monday);
+    sunday.setDate(monday.getDate() + 6);
+    sunday.setHours(23, 59, 59, 999);
+
+    const q = query(
+      collection(db, 'campaigns'),
+      where('date', '>=', Timestamp.fromDate(monday)),
+      where('date', '<=', Timestamp.fromDate(sunday))
+    );
+
+    const unsubscribe = onSnapshot(q, async (snap) => {
+      const temp = { 1: [], 2: [], 3: [], 4: [], 5: [], 6: [], 0: [] };
+      for (const d of snap.docs) {
+        const data = d.data();
+        const campaignDate = data.date?.seconds ? new Date(data.date.seconds * 1000) : new Date(data.date);
+        const sellerRef = doc(db, 'sellers', data.sellerUid);
+        const sellerSnap = await getDoc(sellerRef);
+        const name = sellerSnap.exists() ? sellerSnap.data().name : '알수없음';
+        temp[campaignDate.getDay()].push({ id: d.id, name, quantity: data.quantity });
+      }
+      setSchedule(temp);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+
   return (
     <SellerLayout>
       <h2 className="text-2xl font-bold mb-4">예약 시트</h2>
-      <p>일주일 단위 예약 일정이 이곳에 표시됩니다. (준비 중)</p>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {dayNames.map((dayName, idx) => (
+          <div key={dayName} className="bg-white p-4 rounded-lg shadow">
+            <h3 className="font-semibold mb-2">{dayName}</h3>
+            {schedule[idx] && schedule[idx].length > 0 ? (
+              <ul className="text-sm space-y-1">
+                {schedule[idx].map((c) => (
+                  <li key={c.id} className="flex justify-between">
+                    <span>{c.name} ({c.id.slice(0, 6)})</span>
+                    <span>{c.quantity}개</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-gray-400 text-sm">예약 없음</p>
+            )}
+          </div>
+        ))}
+      </div>
     </SellerLayout>
   );
 }

--- a/pages/seller/progress.js
+++ b/pages/seller/progress.js
@@ -1,10 +1,58 @@
+import { useEffect, useState } from 'react';
 import SellerLayout from '../../components/seller/SellerLayout';
+import { db, auth } from '../../lib/firebase';
+import { collection, query, where, onSnapshot } from 'firebase/firestore';
+import { useAuthState } from 'react-firebase-hooks/auth';
 
 export default function ProgressPage() {
+  const [user] = useAuthState(auth);
+  const [campaigns, setCampaigns] = useState([]);
+
+  useEffect(() => {
+    if (!user) return;
+    const q = query(collection(db, 'campaigns'), where('sellerUid', '==', user.uid));
+    const unsubscribe = onSnapshot(q, (snap) => {
+      setCampaigns(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+    });
+    return () => unsubscribe();
+  }, [user]);
+
+  const getStatus = (c) => {
+    if (c.status === '리뷰완료') return '리뷰완료';
+    if (c.status === '구매완료') return '구매완료';
+    const d = c.date?.seconds ? new Date(c.date.seconds * 1000) : new Date(c.date);
+    return new Date() < d ? '진행전' : '진행중';
+  };
+
   return (
     <SellerLayout>
       <h2 className="text-2xl font-bold mb-4">진행현황</h2>
-      <p>관리자가 설정한 상태에 따라 진행 상황이 표시됩니다. (준비 중)</p>
+      <table className="min-w-full bg-white rounded-lg shadow">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="px-4 py-2 text-left text-sm">순번</th>
+            <th className="px-4 py-2 text-left text-sm">진행일자</th>
+            <th className="px-4 py-2 text-left text-sm">상품명</th>
+            <th className="px-4 py-2 text-left text-sm">상태</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {campaigns.map((c, idx) => {
+            const d = c.date?.seconds ? new Date(c.date.seconds * 1000) : new Date(c.date);
+            return (
+              <tr key={c.id} className="text-sm">
+                <td className="px-4 py-2">{idx + 1}</td>
+                <td className="px-4 py-2">{d.toLocaleDateString()}</td>
+                <td className="px-4 py-2">{c.productName}</td>
+                <td className="px-4 py-2">{getStatus(c)}</td>
+              </tr>
+            );
+          })}
+          {campaigns.length === 0 && (
+            <tr><td colSpan="4" className="text-center py-4 text-gray-500">등록된 캠페인이 없습니다.</td></tr>
+          )}
+        </tbody>
+      </table>
     </SellerLayout>
   );
 }

--- a/pages/seller/traffic.js
+++ b/pages/seller/traffic.js
@@ -1,10 +1,52 @@
+import { useEffect, useState } from 'react';
 import SellerLayout from '../../components/seller/SellerLayout';
+import { db, auth } from '../../lib/firebase';
+import { collection, query, where, onSnapshot } from 'firebase/firestore';
+import { useAuthState } from 'react-firebase-hooks/auth';
 
 export default function TrafficPage() {
+  const [user] = useAuthState(auth);
+  const [campaigns, setCampaigns] = useState([]);
+
+  useEffect(() => {
+    if (!user) return;
+    const q = query(collection(db, 'campaigns'), where('sellerUid', '==', user.uid));
+    const unsubscribe = onSnapshot(q, (snap) => {
+      setCampaigns(snap.docs.map(d => ({ id: d.id, ...d.data() })));
+    });
+    return () => unsubscribe();
+  }, [user]);
+
   return (
     <SellerLayout>
       <h2 className="text-2xl font-bold mb-4">트래픽</h2>
-      <p>순번, 종류, 진행일자, 종료일자 등이 표시됩니다. (준비 중)</p>
+      <table className="min-w-full bg-white rounded-lg shadow">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="px-4 py-2 text-left text-sm">순번</th>
+            <th className="px-4 py-2 text-left text-sm">종류</th>
+            <th className="px-4 py-2 text-left text-sm">진행일자</th>
+            <th className="px-4 py-2 text-left text-sm">종료일자</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {campaigns.map((c, idx) => {
+            const start = c.date?.seconds ? new Date(c.date.seconds * 1000) : new Date(c.date);
+            const end = new Date(start.getTime() + 30 * 24 * 60 * 60 * 1000);
+            return (
+              <tr key={c.id} className="text-sm">
+                <td className="px-4 py-2">{idx + 1}</td>
+                <td className="px-4 py-2">{c.deliveryType}</td>
+                <td className="px-4 py-2">{start.toLocaleDateString()}</td>
+                <td className="px-4 py-2">{end.toLocaleDateString()}</td>
+              </tr>
+            );
+          })}
+          {campaigns.length === 0 && (
+            <tr><td colSpan="4" className="text-center py-4 text-gray-500">데이터가 없습니다.</td></tr>
+          )}
+        </tbody>
+      </table>
     </SellerLayout>
   );
 }


### PR DESCRIPTION
## Summary
- show reservation sheet as first tab and query weekly campaigns
- keep seller campaigns synced from Firestore
- add progress and traffic pages with real data
- allow admin to set campaign status to purchase/review complete

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a240040c83238df9559e4bdc23cf