### PR TITLE
Implement nickname and schedule capacity features

### DIFF
--- a/components/admin/AdminLayout.js
+++ b/components/admin/AdminLayout.js
@@ -22,6 +22,11 @@ export default function AdminLayout({ children }) {
                 판매자 관리
               </Link>
             </li>
+            <li className="mb-4">
+              <Link href="/admin/schedule" className="hover:bg-gray-700 p-2 rounded block">
+                예약 시트 관리
+              </Link>
+            </li>
           </ul>
         </nav>
       </aside>

--- a/pages/admin/schedule.js
+++ b/pages/admin/schedule.js
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+import AdminLayout from '../../components/admin/AdminLayout';
+import withAdminAuth from '../../hoc/withAdminAuth';
+import { db } from '../../lib/firebase';
+import { collection, query, where, onSnapshot, Timestamp, doc, getDoc, setDoc } from 'firebase/firestore';
+
+function AdminSchedule() {
+  const [schedule, setSchedule] = useState({});
+  const [totals, setTotals] = useState({});
+  const [capacities, setCapacities] = useState({});
+  const [weekDates, setWeekDates] = useState([]);
+
+  useEffect(() => {
+    const today = new Date();
+    const day = today.getDay();
+    const diff = today.getDate() - day + (day === 0 ? -6 : 1);
+    const monday = new Date(today.setDate(diff));
+    monday.setHours(0,0,0,0);
+
+    const days = [];
+    for(let i=0;i<7;i++){
+      const d = new Date(monday);
+      d.setDate(monday.getDate()+i);
+      days.push(d);
+    }
+    setWeekDates(days);
+
+    const sunday = new Date(monday);
+    sunday.setDate(monday.getDate()+6);
+    sunday.setHours(23,59,59,999);
+
+    const q = query(
+      collection(db,'campaigns'),
+      where('date','>=',Timestamp.fromDate(monday)),
+      where('date','<=',Timestamp.fromDate(sunday))
+    );
+
+    const unsubscribe = onSnapshot(q, async (snap) => {
+      const temp = {1:[],2:[],3:[],4:[],5:[],6:[],0:[]};
+      const sums = {1:0,2:0,3:0,4:0,5:0,6:0,0:0};
+      for(const d of snap.docs){
+        const data = d.data();
+        const cDate = data.date?.seconds ? new Date(data.date.seconds*1000) : new Date(data.date);
+        const sellerSnap = await getDoc(doc(db,'sellers', data.sellerUid));
+        const nickname = sellerSnap.exists() ? (sellerSnap.data().nickname || sellerSnap.data().name) : '알수없음';
+        temp[cDate.getDay()].push({ id:d.id, nickname, quantity:data.quantity });
+        sums[cDate.getDay()] += Number(data.quantity || 0);
+      }
+      setSchedule(temp);
+      setTotals(sums);
+    });
+
+    const loadCaps = async () => {
+      const caps = {};
+      for(const d of days){
+        const dateStr = d.toISOString().slice(0,10);
+        const snap = await getDoc(doc(db,'capacities',dateStr));
+        caps[dateStr] = snap.exists()? snap.data().capacity : 0;
+      }
+      setCapacities(caps);
+    };
+    loadCaps();
+
+    return () => unsubscribe();
+  }, []);
+
+  const handleCapChange = async (dateStr, value) => {
+    await setDoc(doc(db,'capacities',dateStr), { capacity: Number(value) });
+    setCapacities(prev => ({ ...prev, [dateStr]: Number(value) }));
+  };
+
+  const dayNames = ['일','월','화','수','목','금','토'];
+
+  return (
+    <AdminLayout>
+      <h2 className="text-2xl font-bold mb-4">예약 시트 관리</h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-7 gap-4">
+        {weekDates.map(d => {
+          const idx = d.getDay();
+          const dateStr = d.toISOString().slice(0,10);
+          return (
+            <div key={dateStr} className="bg-white p-4 rounded shadow">
+              <h3 className="font-semibold mb-2">{dayNames[idx]} {dateStr}</h3>
+              {schedule[idx] && schedule[idx].length>0 ? (
+                <ul className="text-sm space-y-1">
+                  {schedule[idx].map(c => (
+                    <li key={c.id} className="flex justify-between">
+                      <span>{c.nickname}</span>
+                      <span>{c.quantity}개</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-gray-400 text-sm">예약 없음</p>
+              )}
+              <div className="mt-2 text-right text-sm font-semibold">
+                합계: {totals[idx] || 0}개
+              </div>
+              <input
+                type="number"
+                value={capacities[dateStr] || ''}
+                onChange={e => handleCapChange(dateStr, e.target.value)}
+                className="mt-2 w-full p-1 border rounded"
+              />
+            </div>
+          );
+        })}
+      </div>
+      <table className="mt-6 min-w-full bg-white rounded shadow">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="px-4 py-2">날짜</th>
+            <th className="px-4 py-2">총작업가능</th>
+            <th className="px-4 py-2">진행예약</th>
+            <th className="px-4 py-2">잔여예약</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {weekDates.map(d => {
+            const idx = d.getDay();
+            const dateStr = d.toISOString().slice(0,10);
+            return (
+              <tr key={dateStr} className="text-center text-sm">
+                <td className="px-4 py-2">{dayNames[idx]} {dateStr}</td>
+                <td className="px-4 py-2">{capacities[dateStr] || 0}</td>
+                <td className="px-4 py-2">{totals[idx] || 0}</td>
+                <td className="px-4 py-2">{(capacities[dateStr] || 0) - (totals[idx] || 0)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </AdminLayout>
+  );
+}
+
+export default withAdminAuth(AdminSchedule);

--- a/pages/seller/index.js
+++ b/pages/seller/index.js
@@ -5,13 +5,25 @@ import { collection, query, where, onSnapshot, Timestamp, getDoc, doc } from 'fi
 
 export default function SellerHome() {
   const [schedule, setSchedule] = useState({});
+  const [totals, setTotals] = useState({});
+  const [capacities, setCapacities] = useState({});
+  const [weekDates, setWeekDates] = useState([]);
 
   useEffect(() => {
     const today = new Date();
     const day = today.getDay();
-    const diff = today.getDate() - day + (day === 0 ? -6 : 1); // Monday as start
+    const diff = today.getDate() - day + (day === 0 ? -6 : 1);
     const monday = new Date(today.setDate(diff));
     monday.setHours(0, 0, 0, 0);
+
+    const dates = [];
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(monday);
+      d.setDate(monday.getDate() + i);
+      dates.push(d);
+    }
+    setWeekDates(dates);
+
     const sunday = new Date(monday);
     sunday.setDate(monday.getDate() + 6);
     sunday.setHours(23, 59, 59, 999);
@@ -24,16 +36,30 @@ export default function SellerHome() {
 
     const unsubscribe = onSnapshot(q, async (snap) => {
       const temp = { 1: [], 2: [], 3: [], 4: [], 5: [], 6: [], 0: [] };
+      const sums = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 0: 0 };
       for (const d of snap.docs) {
         const data = d.data();
         const campaignDate = data.date?.seconds ? new Date(data.date.seconds * 1000) : new Date(data.date);
         const sellerRef = doc(db, 'sellers', data.sellerUid);
         const sellerSnap = await getDoc(sellerRef);
-        const name = sellerSnap.exists() ? sellerSnap.data().name : '알수없음';
-        temp[campaignDate.getDay()].push({ id: d.id, name, quantity: data.quantity });
+        const nickname = sellerSnap.exists() ? (sellerSnap.data().nickname || sellerSnap.data().name) : '알수없음';
+        temp[campaignDate.getDay()].push({ id: d.id, nickname, quantity: data.quantity });
+        sums[campaignDate.getDay()] += Number(data.quantity || 0);
       }
       setSchedule(temp);
+      setTotals(sums);
     });
+
+    const loadCaps = async () => {
+      const caps = {};
+      for (const d of dates) {
+        const dateStr = d.toISOString().slice(0, 10);
+        const snap = await getDoc(doc(db, 'capacities', dateStr));
+        caps[dateStr] = snap.exists() ? snap.data().capacity : 0;
+      }
+      setCapacities(caps);
+    };
+    loadCaps();
 
     return () => unsubscribe();
   }, []);
@@ -43,15 +69,18 @@ export default function SellerHome() {
   return (
     <SellerLayout>
       <h2 className="text-2xl font-bold mb-4">예약 시트</h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        {dayNames.map((dayName, idx) => (
-          <div key={dayName} className="bg-white p-4 rounded-lg shadow">
-            <h3 className="font-semibold mb-2">{dayName}</h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-7 gap-4">
+        {weekDates.map((d) => {
+          const idx = d.getDay();
+          const dateStr = d.toISOString().slice(0,10);
+          return (
+          <div key={dateStr} className="bg-white p-4 rounded-lg shadow">
+            <h3 className="font-semibold mb-2">{dayNames[idx]} {dateStr}</h3>
             {schedule[idx] && schedule[idx].length > 0 ? (
               <ul className="text-sm space-y-1">
                 {schedule[idx].map((c) => (
                   <li key={c.id} className="flex justify-between">
-                    <span>{c.name} ({c.id.slice(0, 6)})</span>
+                    <span>{c.nickname}</span>
                     <span>{c.quantity}개</span>
                   </li>
                 ))}
@@ -59,9 +88,37 @@ export default function SellerHome() {
             ) : (
               <p className="text-gray-400 text-sm">예약 없음</p>
             )}
+            <div className="mt-2 text-right text-sm font-semibold">
+              합계: {totals[idx] || 0}개 / 총 {capacities[dateStr] || 0} / 잔여 {(capacities[dateStr] || 0) - (totals[idx] || 0)}개
+            </div>
           </div>
-        ))}
+          );
+        })}
       </div>
+      <table className="mt-6 min-w-full bg-white rounded shadow">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="px-4 py-2">날짜</th>
+            <th className="px-4 py-2">총작업가능</th>
+            <th className="px-4 py-2">진행예약</th>
+            <th className="px-4 py-2">잔여예약</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {weekDates.map((d) => {
+            const idx = d.getDay();
+            const dateStr = d.toISOString().slice(0,10);
+            return (
+              <tr key={dateStr} className="text-center text-sm">
+                <td className="px-4 py-2">{dayNames[idx]} {dateStr}</td>
+                <td className="px-4 py-2">{capacities[dateStr] || 0}</td>
+                <td className="px-4 py-2">{totals[idx] || 0}</td>
+                <td className="px-4 py-2">{(capacities[dateStr] || 0) - (totals[idx] || 0)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </SellerLayout>
   );
 }

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -11,13 +11,14 @@ export default function SignupPage() {
   const [phone, setPhone] = useState('');
   const [bNo, setBNo] = useState('');
   const [referrerId, setReferrerId] = useState('');
+  const [nickname, setNickname] = useState('');
   const [username, setUsername] = useState('');
   const [isVerifying, setIsVerifying] = useState(false);
   const router = useRouter();
 
   const handleSignUpAndVerify = async (e) => {
     e.preventDefault();
-    if (!email || !password || !bNo || !name || !phone || !username) {
+    if (!email || !password || !bNo || !name || !phone || !username || !nickname) {
       alert('모든 필드를 입력해주세요.');
       return;
     }
@@ -30,6 +31,18 @@ export default function SignupPage() {
       const bNoQuery = query(collection(db, 'sellers'), where('businessInfo.b_no', '==', bNo));
       const bNoSnap = await getDocs(bNoQuery);
       if (!bNoSnap.empty) throw new Error('이미 등록된 사업자 번호입니다.');
+
+      const phoneQuery = query(collection(db, 'sellers'), where('phone', '==', phone));
+      const phoneSnap = await getDocs(phoneQuery);
+      if (!phoneSnap.empty) throw new Error('이미 사용 중인 전화번호입니다.');
+
+      const usernameQuery = query(collection(db, 'sellers'), where('username', '==', username));
+      const usernameSnap = await getDocs(usernameQuery);
+      if (!usernameSnap.empty) throw new Error('이미 사용 중인 ID입니다.');
+
+      const nicknameQuery = query(collection(db, 'sellers'), where('nickname', '==', nickname));
+      const nicknameSnap = await getDocs(nicknameQuery);
+      if (!nicknameSnap.empty) throw new Error('이미 사용 중인 닉네임입니다.');
 
       const response = await fetch('/api/business/verify', {
         method: 'POST',
@@ -47,6 +60,7 @@ export default function SignupPage() {
           name,
           phone,
           username,
+          nickname,
           referrerId,
           businessInfo: data,
           isVerified: true,
@@ -77,6 +91,7 @@ export default function SignupPage() {
         <input value={bNo} onChange={e => setBNo(e.target.value.replace(/-/g,''))} placeholder="사업자등록번호('-' 제외)" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
         <input value={referrerId} onChange={e => setReferrerId(e.target.value)} placeholder="추천인 ID" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
         <input value={username} onChange={e => setUsername(e.target.value)} placeholder="ID" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
+        <input value={nickname} onChange={e => setNickname(e.target.value)} placeholder="닉네임" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
         <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="PW" style={{ width:'100%', padding:'8px', marginBottom:'10px' }} />
         <button type="submit" disabled={isVerifying} style={{ width:'100%', padding:'10px' }}>
           {isVerifying ? '인증 중...' : '가입하기'}


### PR DESCRIPTION
## Summary
- add nickname field on signup and validate uniqueness
- show weekly reservation sheet with nickname and totals for sellers
- create admin schedule page to manage daily capacities
- link admin schedule page in navigation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a6adb1348323829739fc99d283fe