### PR TITLE
Fix login routing and calendar link

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -38,9 +38,9 @@ export default function LoginPage() {
       if (snap.empty) throw new Error('존재하지 않는 ID입니다.');
       const { email } = snap.docs[0].data();
       await signInWithEmailAndPassword(auth, email, loginPassword);
-      router.push('/dashboard/products');
+      router.push('/seller');
     } catch (error) {
-      alert(`로그인 실패: ${error.message}`);
+      alert('아이디/비밀번호를 다시 입력해 주세요.');
     }
   };
 
@@ -100,7 +100,7 @@ export default function LoginPage() {
         });
         
         alert(`${data.tax_type} 사업자 인증 및 가입이 완료되었습니다. 바로 로그인됩니다.`);
-        router.push('/dashboard/products');
+        router.push('/seller');
 
       } else {
         alert(`인증 실패: ${data.b_stt || data.message || '알 수 없는 오류'}`);
@@ -120,7 +120,7 @@ export default function LoginPage() {
       {user ? (
         <div style={{ border: '1px solid #ccc', padding: '20px', marginBottom: '20px', textAlign: 'center' }}>
           <p>{user.email}님, 환영합니다.</p>
-          <button onClick={() => router.push('/dashboard/products')} style={{ width: '100%', padding: '10px', marginTop: '10px' }}>대시보드로 이동</button>
+          <button onClick={() => router.push('/seller')} style={{ width: '100%', padding: '10px', marginTop: '10px' }}>대시보드로 이동</button>
           <button onClick={handleLogout} style={{ width: '100%', padding: '10px', marginTop: '10px', backgroundColor: 'grey', color: 'white' }}>로그아웃</button>
         </div>
       ) : (

--- a/pages/seller/index.js
+++ b/pages/seller/index.js
@@ -145,7 +145,7 @@ function SellerHome() {
                 <div className="flex flex-col items-center justify-center flex-grow pb-2">
                     <div className="text-xs text-gray-500">잔여</div>
                     {remaining > 0 && capacity > 0 ? (
-                        <Link href={`/seller/reservations?date=${dateStr}`} legacyBehavior>
+                        <Link href={`/dashboard/products?date=${dateStr}`} legacyBehavior>
                             <a className={`font-bold ${remainingTextSize} ${remainingColor} cursor-pointer hover:underline`}>
                                 {remaining}
                             </a>


### PR DESCRIPTION
## Summary
- show Korean error message when login fails
- send users to reservation sheet after login
- open reservation page when clicking calendar remaining numbers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687092c933cc8323b702b97e46b18abf