### PR TITLE
Add payment type columns to progress pages

### DIFF
--- a/components/admin/AdminLayout.js
+++ b/components/admin/AdminLayout.js
@@ -27,6 +27,11 @@ export default function AdminLayout({ children }) {
                 예약 시트 관리
               </Link>
             </li>
+            <li className="mb-4">
+              <Link href="/admin/progress" className="hover:bg-gray-700 p-2 rounded block">
+                진행현황
+              </Link>
+            </li>
           </ul>
         </nav>
       </aside>


### PR DESCRIPTION
## Summary
- show progress tab in admin sidebar
- support editing payment type on new `/admin/progress` page
- display payment type on seller progress page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b89402448323b3c7885b079c2e4e