### PR TITLE
Fix viewport for desktop-like view

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -5,7 +5,7 @@ export default function Document() {
     <Html lang="ko">
       <Head>
         <script src="https://js.tosspayments.com/v1/payment-widget"></script>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=1024" />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
## Summary
- adjust viewport meta so mobile shows desktop layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870d58d67608323864aad7dfab28e97