### PR TITLE
Shorten product URL text on admin progress page

### DIFF
--- a/pages/admin/progress.js
+++ b/pages/admin/progress.js
@@ -104,7 +104,7 @@ function AdminProgress() {
                 <td className="px-2 py-2">{c.productName}</td>
                 <td className="px-2 py-2">{c.productOption}</td>
                 <td className="px-2 py-2">{Number(c.productPrice).toLocaleString()}</td>
-                <td className="px-2 py-2 break-all"><a href={c.productUrl} className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">{c.productUrl}</a></td>
+                <td className="px-2 py-2 break-all"><a href={c.productUrl} className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">바로가기</a></td>
                 <td className="px-2 py-2">{c.keywords}</td>
                 <td className="px-2 py-2">-</td>
                 <td className="px-2 py-2">-</td>


### PR DESCRIPTION
## Summary
- update the product URL column on the admin progress page to show `바로가기` instead of the full link

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870dd22a2108323bc24c6a683baeb41